### PR TITLE
Fix few canonical script issues

### DIFF
--- a/tools/datatype-expansion/examples/nodejs/index.js
+++ b/tools/datatype-expansion/examples/nodejs/index.js
@@ -16,6 +16,10 @@ type_expander.expandedForm(typesContext["Device"], typesContext, function(err, e
 
   type_expander.canonicalForm(expanded, function(err, canonical) {
     // canonical contains the computed canonical form
+    if(err) {
+      console.log(err);
+      return;
+    }
     console.log(JSON.stringify(canonical, null, 2));
   });
 });

--- a/tools/datatype-expansion/examples/nodejs/ramls/type_collections.raml
+++ b/tools/datatype-expansion/examples/nodejs/ramls/type_collections.raml
@@ -73,3 +73,67 @@ types:
           "kind": "Stamp Collecting"
         }
       }
+  InlinedDeclaration:
+    type:
+      type: object
+      properties:
+        stringProperty:
+          type: string
+        numberProperty:
+          type: number
+
+  ValidConstraintsInheritance:
+    minProperties: 2
+    maxProperties: 9
+    properties:
+      name:
+        type: string
+        required: true
+        minLength: 4
+        maxLength: 9
+        enum: ["Jane", "John"]
+      age:
+        type: integer
+        minimum: 19
+        maximum: 98
+      cats:
+        type: array
+        items: string
+        minItems: 2
+        maxItems: 4
+      bio:
+        type: object
+        minProperties: 2
+        maxProperties: 9
+    type:
+      type: object
+      discriminator: name
+      discriminatorValue: "John"
+      additionalProperties: false
+      minProperties: 1
+      maxProperties: 10
+      properties:
+        name:
+          type: string
+          required: false
+          minLength: 3
+          maxLength: 10
+          pattern: foobar
+          enum: ["Jane", "John", "Markus"]
+        age:
+          type: integer
+          minimum: 18
+          maximum: 99
+        dob:
+          type: datetime
+          format: rfc2616
+        cats:
+          type: array
+          items: string
+          uniqueItems: true
+          minItems: 1
+          maxItems: 5
+        bio:
+          type: object
+          minProperties: 1
+          maxProperties: 10


### PR DESCRIPTION
Issues fixed:
- maxItems of subtype is checked against itself in `lt-restriction`.
- enum constraint was comparing vectors instead of sets thus giving wrong results (lt-restriction). To test try getting canonical form of this type (on master branch):

```
Person:
  properties:
    name:
      type: string
      enum: ["Jane", "John"]
  type:
    type: object
    properties:
      name:
        type: string
        enum: ["Jane", "John", "Markus"]
```
- minItems/maxItems consistency check is either not performed or always succeeds. Only occurs when set on object properties. Top-level minItems/maxItems are checked properly. To test, try getting canonical form of this type and script will not report an error (on master branch):

```
Person:
  properties:
    names:
      type: array
      items: string
      minItems: 3
      maxItems: 1
```
- When properties' restrictions create a non-consistency after inheritance is done, this inconsistency is not reported. Only in following types: array, object. Types to test (transforming to canonical will succeed) (on master branch):

```
Person:
  properties:
    names:
      type: array
      items: string
      minItems: 3
  type:
    properties:
      names:
        type: array
        items: string
        maxItems: 1
```

```
Person:
  properties:
    bio:
      type: object
      minProperties: 3
  type:
    properties:
      bio:
        type: object
        maxProperties: 1
```
- Also added error log to canonical form convertion in `index.js` and two new types: `InlinedDeclaration` which demos inline type inheritance and `ValidConstraintsInheritance` with all the valid restrictions constraints.
