### PR TITLE
Adding missing time-only type

### DIFF
--- a/tools/datatype-expansion/src/clj/datatype_expansion/canonical_form.cljc
+++ b/tools/datatype-expansion/src/clj/datatype_expansion/canonical_form.cljc
@@ -146,12 +146,17 @@
                                                consistency-check))
 (defmethod lt ["boolean" "boolean"] [super sub] (->> (lt-restrictions super sub)
                                                      (consistency-check)))
+
 (defmethod lt ["datetime" "datetime"] [super sub] (->> (lt-restrictions super sub)
                                                        (consistency-check)))
+
 (defmethod lt ["datetime-only" "datetime-only"] [super sub] (->> (lt-restrictions super sub)
                                                                  (consistency-check)))
 
 (defmethod lt ["date-only" "date-only"] [super sub] (->> (lt-restrictions super sub)
+                                                         (consistency-check)))
+
+(defmethod lt ["time-only" "time-only"] [super sub] (->> (lt-restrictions super sub)
                                                          (consistency-check)))
 
 (defmethod lt ["number" "number"] [super sub] (->> (lt-restrictions super sub)


### PR DESCRIPTION
I am using datatype-expansion and I realized that `time-only` type is missing in the code, and the library just ignore these kind of properties. I just add the missing type.