### PR TITLE
Fix object and array types not supported in type array form (#59)

### DIFF
--- a/algorithms.md
+++ b/algorithms.md
@@ -133,7 +133,7 @@ The input for the algorithm is:
       3. if `form` has a `items` key defined, we initialize `type` with the value `object`
       4. otherwise we initialise `type` with the value passed in `top-level-type`
    2. if `type` is a `String` with  value `array`
-      1. we initialize the value `expanded-items` with the result of invoking the algorithm on the value in `form` for the key `items`
+      1. we initialize the value `expanded-items` with the result of invoking the algorithm on the value in `form` for the key `items` (or `any` if the key `items` is not defined)
       2. we replace the value of the key `items` in `form` by `expanded-items`
    3. if `type` is a `String` with value `object`
       1. we iterate over the `Record` associated to the key `properties` in `form`
@@ -213,7 +213,7 @@ The input of the algorithm is:
 2. if `type` is in the set `any boolean datetime datetime-only number integer string null file xml json"`
    1. we return the output of applying the `consistency-check` to the `form`
 3. if `type` is the string `array`
-   1. we initialize the variable `items` with the output of applying the algorithm to the value of the key `items` of the input `form` of type `Record[String]RAMLForm]`
+   1. we initialize the variable `items` with the output of applying the algorithm to the value of the key `items` of the input `form` (or `any` if the key `items` is not defined)
    2. we initialize the variable `items-type` with the value of the `type` property of the `items` variable
    3. if `items-type` has a value `array`
       1. we replace the property `items` in `form` with the value of `items` variable

--- a/src/canonical.js
+++ b/src/canonical.js
@@ -44,7 +44,7 @@ function toCanonical (form) {
   } else if (type === 'array') {
     // 3. if `type` is the string `array`
     // 3.1. we initialize the variable `items` with the output of applying the algorithm to the value of the key `items` of the input `form` of type `Record[String]RAMLForm]`
-    const items = toCanonical(form.items)
+    const items = toCanonical(form.items || {type: 'any'})
     const node = consistencyCheck(form)
     // 3.2. we initialize the variable `items-type` with the value of the `type` property of the `items` variable
     const itemsType = items.type

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -66,7 +66,7 @@ function expandForm (form, bindings, context, topLevel) {
     }
 
     // 1.1. if `form` is a RAML built-in data type, we return `(Record "type" form)`
-    if (types.indexOf(form) !== -1) {
+    if (types.indexOf(form) !== -1 || form === 'object' || form === 'array') {
       return {type: form}
     }
 
@@ -166,7 +166,7 @@ function expandForm (form, bindings, context, topLevel) {
 }
 
 function expandArray (form, bindings, context) {
-  form.items = expandForm(form.items, bindings, context)
+  form.items = expandForm(form.items || 'any', bindings, context)
   return form
 }
 

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -170,6 +170,14 @@ module.exports = {
     ],
     type: 'union'
   },
+  ObjectInTypeArray: {
+    properties: {},
+    type: 'object'
+  },
+  ArrayInTypeArray: {
+    items: { type: 'any' },
+    type: 'array'
+  },
   UnionInTypeArray: {
     anyOf: [
       { type: 'number' },

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -170,6 +170,12 @@ module.exports = {
     ],
     type: 'union'
   },
+  ObjectInTypeArray: {
+    type: [{ type: 'object' }]
+  },
+  ArrayInTypeArray: {
+    type: [{ type: 'array' }]
+  },
   UnionInTypeArray: {
     type: [{
       anyOf: [

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -84,6 +84,12 @@ module.exports = {
   Deprecation: {
     type: 'nil | string'
   },
+  ObjectInTypeArray: {
+    type: ['object']
+  },
+  ArrayInTypeArray: {
+    type: ['array']
+  },
   UnionInTypeArray: {
     type: ['number | string']
   },


### PR DESCRIPTION
Recognize object and array as built-in types in string form
Default array item type to any in expanded and canonical form