### PR TITLE
Fix canonicalization of unions in a type array (#61)

### DIFF
--- a/algorithms.md
+++ b/algorithms.md
@@ -312,8 +312,10 @@ The input of the algorithm is:
 7. if `super-type` is `union` and `sub-type` is `union`
    1. we initialize the variable `accum` to the empty sequence
    2. for each value `elem-super` in the property `of` of `super`
-      1. for each value `elem-sub` in the property `of` of `sub`
-         1. we add to `accum` the output of applying this algorithm to `elem-super` and `elem-sub`
+      1. if `sub.of` is non-empty
+         1. for each value `elem-sub` in the property `of` of `sub`
+            1. we add to `accum` the output of applying this algorithm to `elem-super` and `elem-sub`
+      2. else if `sub.of` is empty, add `elem-super` to `accum`
    3. for each restriction in `super` and `sub` we compute the narrower restriction and we assign it in `sub`
    4. for each restriction only in `super` we assign it directly to `sub`
    5. we assign the value of the key `of` in `sub` to be `accum`
@@ -354,7 +356,7 @@ The other algorithm is `consistency-check`. It just iterates through all the pos
 
 | check name | restrictions | check |
 |------------|------------|-------|
-| num-properites| `minProperties` and `maxProperties` | `minProperties` <= `maxProperties` |
+| num-properties| `minProperties` and `maxProperties` | `minProperties` <= `maxProperties` |
 | length| `minLength` and `maxLength` | `minLength` <= `maxLength` |
 | size| `minimum` and `maximum` | `minimum` <= `maximum` |
 | num-items | `minItems` and `maxItems` | `minItems` <= `maxItems` |

--- a/src/minType.js
+++ b/src/minType.js
@@ -243,10 +243,16 @@ function minType (sup, sub) {
     const accum = []
     // 7.2. for each value `elem-super` in the property `of` of `super`
     for (let elemSuper of sup.anyOf) {
-      // 7.2.1. for each value `elem-sub` in the property `of` of `sub`
-      for (let elemSub of sub.anyOf) {
-        // 7.2.1.1. we add to `accum` the output of applying this algorithm to `elem-super` and `elem-sub`
-        accum.push(minType(elemSuper, elemSub))
+      // 7.2.1. if `sub.of` is non-empty
+      if (sub.anyOf.length > 0) {
+        // 7.2.1.1. for each value `elem-sub` in the property `of` of `sub`
+        for (let elemSub of sub.anyOf) {
+          // 7.2.1.1.1. we add to `accum` the output of applying this algorithm to `elem-super` and `elem-sub`
+          accum.push(minType(elemSuper, elemSub))
+        }
+      } else {
+        // 7.2.2. else if `sub.of` is empty, add `elem-super` to `accum`
+        accum.push(elemSuper)
       }
     }
 

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -170,6 +170,13 @@ module.exports = {
     ],
     type: 'union'
   },
+  UnionInTypeArray: {
+    anyOf: [
+      { type: 'number' },
+      { type: 'string' }
+    ],
+    type: 'union'
+  },
   SimpleUnion: {
     additionalProperties: true,
     type: 'union',

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -170,6 +170,19 @@ module.exports = {
     ],
     type: 'union'
   },
+  UnionInTypeArray: {
+    type: [{
+      anyOf: [
+        {
+          type: 'number'
+        },
+        {
+          type: 'string'
+        }
+      ],
+      type: 'union'
+    }]
+  },
   SimpleUnion: {
     properties: {
       a: {

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -84,6 +84,9 @@ module.exports = {
   Deprecation: {
     type: 'nil | string'
   },
+  UnionInTypeArray: {
+    type: ['number | string']
+  },
   SimpleUnion: {
     properties: {
       a: 'string',


### PR DESCRIPTION
Add special case to min-type for unions when sub.of is empty