### PR TITLE
Fix minType 6.3 to check for non-common properties in`properties`

### DIFF
--- a/src/minType.js
+++ b/src/minType.js
@@ -204,20 +204,22 @@ function minType (sup, sub) {
   if (superType === 'object' && subType === 'object') {
     // 6.1. for initialize the variable `common-props` to the empty record
     const commonProps = {}
-    let superProps = Object.keys(sup.properties || {})
-    let subProps = Object.keys(sub.properties || {})
+    const superProps = sup.properties || {}
+    const subProps = sub.properties || {}
+    const superPropKeys = Object.keys(superProps)
+    const subPropKeys = Object.keys(subProps)
     // 6.2. for each key in the `properties` value `sub` that is also present in the `properties` value of `super`
-    superProps.filter(p => subProps.indexOf(p) !== -1).forEach((p) => {
+    superPropKeys.filter(p => p in subProps).forEach((p) => {
       // 6.2.1. we initialize the variable `tmp` with the output of applying the algorithm to the value for the common property in `super` and in `sub`
       // 6.2.2. we assign the computed value using the name of the common property as the key in the `common-props` record
       commonProps[p] = minType(sup.properties[p], sub.properties[p])
     })
 
     // 6.3. for each pair `property-name` `property-value` only in either `super` or `sub` we add it to the record `common-props`
-    superProps.filter(p => !(p in sub)).forEach((p) => {
+    superPropKeys.filter(p => !(p in subProps)).forEach((p) => {
       commonProps[p] = sup.properties[p]
     })
-    subProps.filter(p => !(p in sub)).forEach((p) => {
+    subPropKeys.filter(p => !(p in superProps)).forEach((p) => {
       commonProps[p] = sub.properties[p]
     })
 

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -913,5 +913,30 @@ module.exports = {
     minItems: 2,
     maxItems: 3,
     additionalProperties: true
+  },
+  Named: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  InheritNamedWithNameAttribute: {
+    name: 'InheritNamedWithNameAttribute',
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        required: true
+      },
+      other: {
+        type: 'string',
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1054,5 +1054,35 @@ module.exports = {
     minItems: 2,
     maxItems: 3,
     additionalProperties: true
+  },
+  Named: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  InheritNamedWithNameAttribute: {
+    name: 'InheritNamedWithNameAttribute',
+    type: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          required: true
+        }
+      },
+      additionalProperties: true
+    },
+    properties: {
+      other: {
+        type: 'string',
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -448,5 +448,17 @@ module.exports = {
     maxLength: 3,
     minItems: 2,
     maxItems: 3
+  },
+  Named: {
+    properties: {
+      name: 'string'
+    }
+  },
+  InheritNamedWithNameAttribute: {
+    name: 'InheritNamedWithNameAttribute',
+    type: 'Named',
+    properties: {
+      other: 'string'
+    }
   }
 }


### PR DESCRIPTION
This change also optimizes common property search to be O(1) using hash lookup instead of O(N) using `Array.indexOf`.