### PR TITLE
Replace O(N) util.types.indexOf with O(1) util.isOpaqueType

### DIFF
--- a/src/canonical.js
+++ b/src/canonical.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 
 const minType = require('./minType')
 const consistencyCheck = require('./util').consistencyCheck
-const types = require('./util').types
+const isOpaqueType = require('./util').isOpaqueType
 
 /**
  * Accepts a JSON in-memory representation of an expanded RAML type and a
@@ -37,7 +37,7 @@ function toCanonical (form) {
   // 1. we initialize the variable type with the value of the property `type` of `expanded-form`
   const type = form.type
 
-  if (types.indexOf(type) !== -1) {
+  if (isOpaqueType(type)) {
     // 2. if `type` is in the set `any boolean datetime datetime-only number integer string null file xml json`
     // 2.1. we return the output of applying the `consistency-check` to the `form`
     return consistencyCheck(form)

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 
-const types = require('./util').types
+const isOpaqueType = require('./util').isOpaqueType
 
 /**
  * Accepts an in-memory JSON representation of the type, the types mapping
@@ -66,12 +66,12 @@ function expandForm (form, bindings, context, topLevel) {
     }
 
     // 1.1. if `form` is a RAML built-in data type, we return `(Record "type" form)`
-    if (types.indexOf(form) !== -1 || form === 'object' || form === 'array') {
+    if (isOpaqueType(form) || form === 'object' || form === 'array') {
       return {type: form}
     }
 
     if (form.endsWith('?')) {
-      if (types.indexOf(form.replace('?', '')) !== -1) {
+      if (isOpaqueType(form.replace('?', ''))) {
         return expandUnion({
           type: 'union',
           anyOf: [

--- a/src/minType.js
+++ b/src/minType.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash')
 
-const types = require('./util').types
+const isOpaqueType = require('./util').isOpaqueType
 const consistencyCheck = require('./util').consistencyCheck
 
 /**
@@ -131,7 +131,7 @@ function minType (sup, sub) {
   const superType = sup.type
   const subType = sub.type
   // 2. if `super-type` and `sub-type` have the same value and the value is in the set `any boolean datetime datetime-only number integer string null file xml json"`
-  if (superType === subType && types.indexOf(superType) !== -1) {
+  if (superType === subType && isOpaqueType(superType)) {
     // 2.1. we initialize the variable `computed` to the record with property `type` having the common `super-type` and `sub-type` value
     const computed = _.cloneDeep(sup)
     for (let restriction in restrictions) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,9 @@
 'use strict'
 
-// is this correct?
-module.exports.types = [
+const _ = require('lodash')
+
+// scalar types + [any, xml, json], excludes [array, object, union]
+const opaqueTypes = _.keyBy([
   'any',
   'boolean',
   'date-only',
@@ -15,7 +17,11 @@ module.exports.types = [
   'file',
   'xml',
   'json'
-]
+])
+
+module.exports.isOpaqueType = function isOpaqueType (type) {
+  return type in opaqueTypes
+}
 
 /**
  * Iterates through all the possible restriction constraints defined in the RAML specification and checks that the constraints hold for the provided type using custom logic.


### PR DESCRIPTION
This is just a minor improvement to make it more clear what `util.types` means and encapsulate its implementation. Using a map instead of an array should theoretically help performance too, but that wasn't the primary goal. My rough measurements mainly show that it's no slower.