### PR TITLE
Fully canonicalize the min-type reduction when type is an array (#68)

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -256,7 +256,7 @@ The input of the algorithm is:
       4. we initialize the variable `canonical-super-type` to the output of applying the algorithm to the value for the property  `type` in `form`
       5. we set the `type` property of `form` to `super-type-name`
    2. we initialize the variable `tmp` with the output of invoking the algorithm `min-type` to the inputs `canonical-super-type` and `form`
-   3. we run `canonical-type` on the output of applying the `consistency-check` algorithm to the modified value of `tmp`
+   3. we return the output of recursively applying the algorithm to the modified value of `tmp`
 6. if `type` is `Seq[RAMLForm]`
    1. we initialize the variable `super-type-name` to the first value of type string in the chain of nested records for the value `type` starting with the one assigned to `type` in `form`
       1. if `super-type-name` has a value `array` we transform `form` adding the property `items` pointing a record `(Record "type" "any")`
@@ -267,7 +267,7 @@ The input of the algorithm is:
    2. for each value `elem` in `super-types`
       1. we initialize the variable `tmp` with the output of computing the result of invoking the algorithm `min-type` to `elem` and `form`
       2. we re-assign `form` to the value computed in `tmp`
-   3. we run `canonical-type` on the output of applying the `consistency-check` algorithm to the modified value of `tmp`
+   3. we return the output of recursively applying the algorithm to the modified value of `tmp`
 
 In the previous algorithm we have used two auxiliary algorithms `min-type` and `consistency-check`.
 

--- a/src/canonical.js
+++ b/src/canonical.js
@@ -156,11 +156,10 @@ function toCanonical (form) {
     if (Array.isArray(type)) {
       const superTypes = _.cloneDeep(type).map(t => toCanonical(t))
       subType = superTypes.reduce((acc, val) => minType(val, acc), subType)
-      const res = consistencyCheck(subType)
-      return toCanonical(res)
+      return toCanonical(subType)
     } else {
       const superType = toCanonical(type)
-      const res = consistencyCheck(minType(superType, subType))
+      const res = minType(superType, subType)
       return toCanonical(res)
     }
   }

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1116,5 +1116,18 @@ module.exports = {
       }
     },
     additionalProperties: true
+  },
+  CanonicalItemsTypeArray: {
+    type: 'object',
+    properties: {
+      prop: {
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1263,5 +1263,22 @@ module.exports = {
       }
     },
     additionalProperties: true
+  },
+  CanonicalItemsTypeArray: {
+    type: [{
+      type: 'object'
+    }],
+    properties: {
+      prop: {
+        type: 'array',
+        items: {
+          type: [{
+            type: 'string'
+          }]
+        },
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -584,5 +584,15 @@ module.exports = {
         items: 'string'
       }
     }
+  },
+  CanonicalItemsTypeArray: {
+    type: ['object'],
+    properties: {
+      prop: {
+        items: {
+          type: ['string']
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Update canonicalization 5 & 6 in algorithms.md to correctly reflect how recursion is applied as the final step
Remove the redundant consistency-check from canonicalization 5 (Record[String][RAMLForm])