### PR TITLE
Fixing integration in latest raml2obj and api-console

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -310,23 +310,31 @@ The input of the algorithm is:
    5. for each restriction only in `super` we assign it directly to `sub`
    6. we assign the value of the key `properties` in `sub` to be `common-props`
    7. we return the output of computing the algorithm `consistency-check` on `sub`
-7. if `super-type` is `union` and `sub-type` is `union`
-   1. we initialize the variable `accum` to the empty sequence
-   2. for each value `elem-super` in the property `of` of `super`
-      1. if `sub.of` is non-empty
-         1. for each value `elem-sub` in the property `of` of `sub`
-            1. we add to `accum` the output of applying this algorithm to `elem-super` and `elem-sub`
-      2. else if `sub.of` is empty, add `elem-super` to `accum`
-   3. for each restriction in `super` and `sub` we compute the narrower restriction and we assign it in `sub`
-   4. for each restriction only in `super` we assign it directly to `sub`
-   5. we assign the value of the key `of` in `sub` to be `accum`
-   6. we return the output of computing the algorithm `consistency-check` on `sub`
-8. if `super-type` is `union` and `sub-type` is any other type
-   1. for each value `i` `elem-super` in the property `of` of `super`
-      1. we replace `i` in `of` with the output of applying this algorithm to `elem-super` and `sub`
-   2. for each restriction in `super` and `sub` we compute the narrower restriction and we assign it in `super`
-   3. for each restriction only in `sub` we assign it directly to `super`
-   4. we return the output of computing the algorithm `consistency-check` on `super`
+7. if `super-type` is `union` or `sub-type` is `union`
+   1. initialize `computed` to the empty record
+   2. if `super-type` is `union`
+      1. assign its properties to `computed`
+      2. set `sup-of` to `of` of `sup`
+   3. else set `sup-of` to a single element array of `sup`
+   4. if `sub-type` is `union`
+       1. assign its properties to `computed`
+       2. set `sub-of` to `of` of `sub`
+   5. else set `sub-of` to a single element array of `sub`
+   6. initialize `of` of `computed` to the empty array
+   7. if `sup-of` is non-empty
+      1. if `sub-of` is non-empty
+         1. for each value `elem-super` in `sup-of`
+            1. for each value `elem-sub` in `sub-of`
+               1. set `result` to the output of applying this algorithm to `elem-super` and `elem-sub`
+               2. if `result` is a `union`, concatenate its `of` to `of` of `computed`
+               3. else append `result` to `of` of `computed`
+      2. else if `sub-of` is empty, assign `of` of `computed` to `sup-of`
+   8. else if `sup-of` is empty, assign `of` of `computed` to `sup-of`
+   9. for each restriction in unions `super` and `sub` we compute the narrower restriction and we assign it in `computed`
+   10. for each restriction only in union `super` we assign it directly to `computed`
+   11. for each restriction only in union `sub` we assign it directly to `computed`
+   12. we return the output of computing the algorithm `consistency-check` on `computed`
+8. else fail the algorithm due to incompatible types
 
 In the previous algorithm we need to define how the narrower version of a constraint is computed.
 The following table provides the details:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatype-expansion",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Utility tool to expand a given RAML type and create a canonical form",
   "main": "src/index.js",
   "browser": "dist/datatype-expansion.js",

--- a/src/canonical.js
+++ b/src/canonical.js
@@ -158,8 +158,8 @@ function toCanonical (form) {
 
     if (Array.isArray(type)) {
       const superTypes = _.cloneDeep(type).map(t => toCanonical(t))
-      subType = superTypes.reduce((acc, val) => minType(val, acc), subType)
-      return toCanonical(subType)
+      subType = superTypes.reduce((acc, val) => minType(val, acc), toCanonical(subType))
+      return subType
     } else {
       const superType = toCanonical(type)
       const res = minType(superType, subType)

--- a/src/canonical.js
+++ b/src/canonical.js
@@ -94,7 +94,9 @@ function toCanonical (form) {
         // 4.4.3.2. for each value `elem-of` in the property `of` of `tmp`
         tmp.anyOf.forEach((elemOf) => {
           // 4.4.3.2.1. for each value `elem` in `accum`
-          elemOf.required = tmp.required
+          if (typeof form.required === 'boolean') {
+            elemOf.required = tmp.required
+          }
           for (let elem of accum) {
             // 4.4.3.2.1.1. we clone `elem`
             elem = _.cloneDeep(elem)
@@ -163,7 +165,7 @@ function toCanonical (form) {
     } else {
       const superType = toCanonical(type)
       const res = minType(superType, toCanonical(subType))
-      return toCanonical(res)
+      return res
     }
   }
 

--- a/src/canonical.js
+++ b/src/canonical.js
@@ -162,7 +162,7 @@ function toCanonical (form) {
       return subType
     } else {
       const superType = toCanonical(type)
-      const res = minType(superType, subType)
+      const res = minType(superType, toCanonical(subType))
       return toCanonical(res)
     }
   }

--- a/src/minType.js
+++ b/src/minType.js
@@ -279,8 +279,7 @@ function minType (sup, sub) {
 
   // 8. if `super-type` is `union` and `sub-type` is any other type
   if (superType === 'union' && subType !== 'union') {
-    const computed = Object.assign({}, sup, sub)
-    computed.type = superType
+    const computed = Object.assign({}, sup)
     // 8.1. for each value `i` `elem-super` in the property `of` of `super`
     // 8.1.1. we replace `i` in `of` with the output of applying this algorithm to `elem-super` and `sub`
     computed.anyOf = sup.anyOf.map(elem => minType(elem, sub))

--- a/src/minType.js
+++ b/src/minType.js
@@ -299,6 +299,22 @@ function minType (sup, sub) {
     return consistencyCheck(computed)
   }
 
+  if (subType === 'union' && superType !== 'union') {
+    let anyOf = sub.anyOf
+    let unionResult = sub
+    unionResult.anyOf = []
+    for (let i = 0; i < anyOf.length; i++) {
+      let result = minType(anyOf[i], sup)
+      if (result.type === 'union') {
+        unionResult.anyOf.concat(result.anyOf)
+      } else {
+        unionResult.anyOf.push(result)
+      }
+    }
+        // minType should always return a canonical type
+        // so a union of canonical types is canonical
+    return unionResult
+  }
   throw new Error(`incompatible types: [${subType}, ${superType}]`)
 }
 

--- a/src/minType.js
+++ b/src/minType.js
@@ -283,6 +283,7 @@ function minType (sup, sub) {
     computed.type = superType
     // 8.1. for each value `i` `elem-super` in the property `of` of `super`
     // 8.1.1. we replace `i` in `of` with the output of applying this algorithm to `elem-super` and `sub`
+
     computed.anyOf = sup.anyOf.map(elem => minType(elem, sub))
 
     for (let restriction in restrictions) {
@@ -300,7 +301,7 @@ function minType (sup, sub) {
   }
 
   if (subType === 'union' && superType !== 'union') {
-    const computed = Object.assign({}, sup)
+    const computed = Object.assign({}, sub)
     let anyOf = sub.anyOf
     computed.anyOf = []
     for (let i = 0; i < anyOf.length; i++) {

--- a/src/minType.js
+++ b/src/minType.js
@@ -243,64 +243,79 @@ function minType (sup, sub) {
 
   // 7. if `super-type` is `union` or `sub-type` is `union`
   if (superType === 'union' || subType === 'union') {
+    // 7.1. initialize `computed` to the empty record
     const computed = {}
     let supAnyOf, subAnyOf
+    // 7.2. if `super-type` is `union`
     if (superType === 'union') {
+      // 7.2.1. assign its properties to `computed`
       Object.assign(computed, sup)
+      // 7.2.2. set `sup-of` to `of` of `sup`
       supAnyOf = sup.anyOf
     } else {
+      // 7.3. else set `sup-of` to a single element array of `sup`
       supAnyOf = [sup]
     }
+    // 7.4. if `sub-type` is `union`
     if (subType === 'union') {
+      // 7.4.1. assign its properties to `computed`
       Object.assign(computed, sub)
+      // 7.4.2. set `sub-of` to `of` of `sub`
       subAnyOf = sub.anyOf
     } else {
+      // 7.5. else set `sub-of` to a single element array of `sub`
       subAnyOf = [sub]
     }
+    // 7.6. initialize `of` of `computed` to the empty array
     computed.anyOf = []
+    // 7.7. if `sup-of` is non-empty
     if (supAnyOf.length > 0) {
-      // 7.2.1. if `sub.of` is non-empty
+      // 7.7.1. if `sub-of` is non-empty
       if (subAnyOf.length > 0) {
-        // 7.2. for each value `elem-super` in the property `of` of `super`
+        // 7.7.1.1. for each value `elem-super` in `sup-of`
         for (const elemSuper of supAnyOf) {
-          // 7.2.1.1. for each value `elem-sub` in the property `of` of `sub`
+          // 7.7.1.1.1. for each value `elem-sub` in `sub-of`
           for (const elemSub of subAnyOf) {
-            // 7.2.1.1.1. we add to `computed.anyOf` the output of applying this algorithm to `elem-super` and `elem-sub`
+            // 7.7.1.1.1.1. set `result` to the output of applying this algorithm to `elem-super` and `elem-sub`
             const result = minType(elemSuper, elemSub)
+            // 7.7.1.1.1.2. if `result` is a `union`, concatenate its `of` to `of` of `computed`
             if (result.type === 'union') {
               computed.anyOf.concat(result.anyOf)
             } else {
+              // 7.7.1.1.1.3. else append `result` to `of` of `computed`
               computed.anyOf.push(result)
             }
           }
         }
       } else {
-        // 7.2.2. else if `sub.of` is empty, add `elem-super` to `computed.anyOf`
+        // 7.7.2. else if `sub-of` is empty, assign `of` of `computed` to `sup-of`
         computed.anyOf = supAnyOf
       }
     } else {
+      // 7.8. else if `sup-of` is empty, assign `of` of `computed` to `sup-of`
       computed.anyOf = subAnyOf
     }
 
     for (const restriction in restrictions) {
       if (sup[restriction] !== undefined && superType === 'union') {
         if (sub[restriction] !== undefined && subType === 'union') {
-          // 7.3. for each restriction in `super` and `sub` we compute the narrower restriction and we assign it in `computed`
+          // 7.9. for each restriction in unions `super` and `sub` we compute the narrower restriction and we assign it in `computed`
           computed[restriction] = restrictions[restriction](sup[restriction], sub[restriction])
         } else {
-          // 7.4. for each restriction only in `super` we assign it directly to `computed`
+          // 7.10. for each restriction only in union `super` we assign it directly to `computed`
           computed[restriction] = sup[restriction]
         }
       } else if (sub[restriction] !== undefined && subType === 'union') {
-        // 8.3. for each restriction only in `sub` we assign it directly to `computed`
+        // 7.11. for each restriction only in union `sub` we assign it directly to `computed`
         computed[restriction] = sub[restriction]
       }
     }
 
-    // 8.4. we return the output of computing the algorithm `consistency-check` on `computed`
+    // 7.12. we return the output of computing the algorithm `consistency-check` on `computed`
     return consistencyCheck(computed)
   }
 
+  // 8. else fail the algorithm due to incompatible types
   throw new Error(`incompatible types: [${subType}, ${superType}]`)
 }
 

--- a/src/minType.js
+++ b/src/minType.js
@@ -304,7 +304,7 @@ function minType (sup, sub) {
     let unionResult = sub
     unionResult.anyOf = []
     for (let i = 0; i < anyOf.length; i++) {
-      let result = minType(anyOf[i], sup)
+      let result = minType(sup, anyOf[i])
       if (result.type === 'union') {
         unionResult.anyOf.concat(result.anyOf)
       } else {

--- a/src/minType.js
+++ b/src/minType.js
@@ -300,20 +300,20 @@ function minType (sup, sub) {
   }
 
   if (subType === 'union' && superType !== 'union') {
+    const computed = Object.assign({}, sup)
     let anyOf = sub.anyOf
-    let unionResult = sub
-    unionResult.anyOf = []
+    computed.anyOf = []
     for (let i = 0; i < anyOf.length; i++) {
       let result = minType(sup, anyOf[i])
       if (result.type === 'union') {
-        unionResult.anyOf.concat(result.anyOf)
+        computed.anyOf.concat(result.anyOf)
       } else {
-        unionResult.anyOf.push(result)
+        computed.anyOf.push(result)
       }
     }
-        // minType should always return a canonical type
-        // so a union of canonical types is canonical
-    return unionResult
+      // minType should always return a canonical type
+      // so a union of canonical types is canonical
+    return computed
   }
   throw new Error(`incompatible types: [${subType}, ${superType}]`)
 }

--- a/test/canonical.js
+++ b/test/canonical.js
@@ -13,7 +13,7 @@ const canonicalForm = require('..').canonicalForm
 describe('canonicalForm()', function () {
   _.each(types, function (type, name) {
     it('should generate canonical form of type ' + name, function () {
-      // don't run tests for forms that don't exist
+            // don't run tests for forms that don't exist
       if (forms[name] == null) return
 
       const expForm = expandedForm(types[name], types)

--- a/test/canonical.js
+++ b/test/canonical.js
@@ -18,6 +18,7 @@ describe('canonicalForm()', function () {
 
       const expForm = expandedForm(types[name], types)
       const canForm = canonicalForm(expForm)
+
       expect(canForm).to.deep.equal(forms[name])
     })
   })

--- a/test/canonical.js
+++ b/test/canonical.js
@@ -13,12 +13,11 @@ const canonicalForm = require('..').canonicalForm
 describe('canonicalForm()', function () {
   _.each(types, function (type, name) {
     it('should generate canonical form of type ' + name, function () {
-            // don't run tests for forms that don't exist
+      // don't run tests for forms that don't exist
       if (forms[name] == null) return
 
       const expForm = expandedForm(types[name], types)
       const canForm = canonicalForm(expForm)
-
       expect(canForm).to.deep.equal(forms[name])
     })
   })

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1170,5 +1170,56 @@ module.exports = {
       }
     },
     'additionalProperties': true
+  },
+  UnionInheritance2: {
+    'type': 'union',
+    'anyOf': [
+      {
+        'type': 'object',
+        'properties': {
+          'a': {
+            'type': 'string',
+            'required': true,
+            'minLength': 5,
+            'maxLength': 10
+          }
+        },
+        'additionalProperties': true
+      },
+      {
+        'type': 'object',
+        'properties': {
+          'a': {
+            'type': 'string',
+            'required': true,
+            'minLength': 6,
+            'maxLength': 10
+          }
+        },
+        'additionalProperties': true
+      },
+      {
+        'type': 'object',
+        'properties': {
+          'a': {
+            'type': 'string',
+            'required': true,
+            'minLength': 5
+          }
+        },
+        'additionalProperties': true
+      },
+      {
+        'type': 'object',
+        'properties': {
+          'a': {
+            'type': 'string',
+            'required': true,
+            'minLength': 6
+          }
+        },
+        'additionalProperties': true
+      }
+    ]
   }
 }

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1162,13 +1162,6 @@ module.exports = {
         'additionalProperties': true
       }
     ],
-    'properties': {
-      'a': {
-        'type': 'string',
-        'minLength': 4,
-        'required': true
-      }
-    },
     'additionalProperties': true
   },
   UnionInheritance2: {

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1135,5 +1135,55 @@ module.exports = {
         type: 'number'
       }
     }]
+  },
+  Payment: {
+    type: 'union',
+    anyOf: [{
+      type: 'object',
+      properties: {
+        amount: {
+          type: 'number',
+          required: true
+        }
+      },
+      additionalProperties: true
+    }, {
+      type: 'object',
+      properties: {
+        amount: {
+          type: 'string',
+          required: true
+        }
+      },
+      additionalProperties: true
+    }]
+  },
+  Payments: {
+    type: 'union',
+    anyOf: [{
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          amount: {
+            type: 'number',
+            required: true
+          }
+        },
+        additionalProperties: true
+      }
+    }, {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          amount: {
+            type: 'string',
+            required: true
+          }
+        },
+        additionalProperties: true
+      }
+    }]
   }
 }

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -180,8 +180,8 @@ module.exports = {
   },
   UnionInTypeArray: {
     anyOf: [
-      { type: 'number' },
-      { type: 'string' }
+            { type: 'number' },
+            { type: 'string' }
     ],
     type: 'union'
   },
@@ -1135,5 +1135,40 @@ module.exports = {
         type: 'number'
       }
     }]
+  },
+  UnionInheritance: {
+    'type': 'union',
+    'anyOf': [
+      {
+        'type': 'object',
+        'properties': {
+          'a': {
+            'type': 'string',
+            'required': true,
+            'minLength': 4
+          }
+        },
+        'additionalProperties': true
+      },
+      {
+        'type': 'object',
+        'properties': {
+          'a': {
+            'type': 'string',
+            'required': true,
+            'minLength': 4
+          }
+        },
+        'additionalProperties': true
+      }
+    ],
+    'properties': {
+      'a': {
+        'type': 'string',
+        'minLength': 4,
+        'required': true
+      }
+    },
+    'additionalProperties': true
   }
 }

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1161,8 +1161,7 @@ module.exports = {
         },
         'additionalProperties': true
       }
-    ],
-    'additionalProperties': true
+    ]
   },
   UnionInheritance2: {
     'type': 'union',

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1355,5 +1355,45 @@ module.exports = {
       }
     },
     'additionalProperties': true
+  },
+  UnionInheritance2: {
+    'type': {
+      'type': 'object',
+      'properties': {
+        'a': {
+          'type': 'union',
+          'anyOf': [
+            {
+              'type': 'string',
+              'minLength': 2,
+              'maxLength': 10
+            },
+            {
+              'type': 'string',
+              'minLength': 3
+            }
+          ],
+          'required': true
+        }
+      },
+      'additionalProperties': true
+    },
+    'properties': {
+      'a': {
+        'type': 'union',
+        'anyOf': [
+          {
+            'type': 'string',
+            'minLength': 5
+          },
+          {
+            'type': 'string',
+            'minLength': 6
+          }
+        ],
+        'required': true
+      }
+    },
+    'additionalProperties': true
   }
 }

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1325,5 +1325,61 @@ module.exports = {
       type: 'union',
       anyOf: [{ type: 'string' }, { type: 'number' }]
     }
+  },
+  Payment: {
+    type: 'object',
+    properties: {
+      amount: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  Payments: {
+    type: 'array',
+    items: {
+      type: {
+        type: 'object',
+        properties: {
+          amount: {
+            type: 'union',
+            anyOf: [{ type: 'number' }, { type: 'string' }],
+            required: true
+          }
+        },
+        additionalProperties: true
+      }
+    }
+  },
+  PaymentsPage: {
+    type: 'object',
+    properties: {
+      count: {
+        type: 'integer',
+        required: true
+      },
+      results: {
+        type: {
+          type: 'array',
+          items: {
+            type: {
+              type: 'object',
+              properties: {
+                amount: {
+                  type: 'union',
+                  anyOf: [{ type: 'number' }, { type: 'string' }],
+                  required: true
+                }
+              },
+              additionalProperties: true
+            }
+          }
+        },
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1018,8 +1018,8 @@ module.exports = {
   },
   Optional: {
     anyOf: [
-      {type: 'string'},
-      {type: 'nil'}
+            { type: 'string' },
+            { type: 'nil' }
     ],
     type: 'union'
   },
@@ -1325,5 +1325,35 @@ module.exports = {
       type: 'union',
       anyOf: [{ type: 'string' }, { type: 'number' }]
     }
+  },
+  UnionInheritance: {
+    'type': {
+      'type': 'object',
+      'properties': {
+        'a': {
+          'type': 'union',
+          'anyOf': [
+            {
+              'type': 'string',
+              'minLength': 2
+            },
+            {
+              'type': 'string',
+              'minLength': 3
+            }
+          ],
+          'required': true
+        }
+      },
+      'additionalProperties': true
+    },
+    'properties': {
+      'a': {
+        'type': 'string',
+        'minLength': 4,
+        'required': true
+      }
+    },
+    'additionalProperties': true
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -627,5 +627,41 @@ module.exports = {
         minLength: 4
       }
     }
+  },
+  UnionInheritance2: {
+    type: {
+      type: 'object',
+      properties: {
+        'a': {
+          type: 'union',
+          anyOf: [
+            {
+              type: 'string',
+              minLength: 2,
+              maxLength: 10
+            },
+            {
+              type: 'string',
+              minLength: 3
+            }
+          ]
+        }
+      }
+    },
+    properties: {
+      'a': {
+        type: 'union',
+        anyOf: [
+          {
+            type: 'string',
+            minLength: 5
+          },
+          {
+            type: 'string',
+            minLength: 6
+          }
+        ]
+      }
+    }
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -601,5 +601,24 @@ module.exports = {
       type: 'union',
       anyOf: ['string', 'number']
     }
+  },
+  Payment: {
+    properties: {
+      amount: 'number | string'
+    }
+  },
+  Payments: {
+    type: 'array',
+    items: {
+      type: 'Payment'
+    }
+  },
+  PaymentsPage: {
+    properties: {
+      count: 'integer',
+      results: {
+        type: 'Payments'
+      }
+    }
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -601,5 +601,31 @@ module.exports = {
       type: 'union',
       anyOf: ['string', 'number']
     }
+  },
+  UnionInheritance: {
+    type: {
+      type: 'object',
+      properties: {
+        'a': {
+          type: 'union',
+          anyOf: [
+            {
+              type: 'string',
+              minLength: 2
+            },
+            {
+              type: 'string',
+              minLength: 3
+            }
+          ]
+        }
+      }
+    },
+    properties: {
+      'a': {
+        type: 'string',
+        minLength: 4
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixing problem with inheritance from non-canonical base type and computing minType of a union inheriting from a non-union.

We were not canonilising the base type when inheriting.
This can lead to situations where the base type is a union (e.g. union in a property in a object type).
The additional clause in the minType function deals with unions inheriting from non-nunions.

Missing test, errors were coming from using versino 2.5 in raml2obj. Test cases can be taken from there.