### PR TITLE
Allow union hoisting to be disabled in canonicalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ The canonical form computes inheritance and pushes unions to the top level of th
 ### Usage
 
 The Node.js version of the canonical form function is defined in the `canonicalForm` function of the library module.
-It accepts a JSON in-memory representation of an expanded RAML type and a callback function. It returns the canonical form or an exception:
+It accepts a JSON in-memory representation of an expanded RAML type and an optional callback function or options object. It returns the canonical form or an exception. The following options are supported:
+
+* `callback`: Provides a callback function via the options object.
+* `hoistUnions` (default: `true`): Controls whether canonicalization should hoist unions to the top level of the type form. When enabled, `union` can only appear as the top-level type, and the associated type alternatives are the permutation of any nested unions in the input type. When disabled, unions remain nested.
 
 #### Sync API
 ```js

--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -166,17 +166,17 @@ An example Clojure implementation of this algorithm can be found in the `api-mod
 
 A RAML type expressed in canonical form has all the properties of RAML type in expanded form plus the following:
 
-- Unions can only appear at the top level of the type form
-- All inheritance relationships have been resolved
 - All `type` properties have a `String` value
+- All inheritance relationships have been resolved
 - All the constraints defined for the type are valid
+- Unions can only appear at the top level of the type form ("union hoisting", which can be disabled)
 
 The canonical form can be used to represent a RAML type in a unique way. It can also be used to perform validation since inheritance and union types have been resolved.
 
 In order to work with inheritance over RAML types we will consider standard set inclusion semantics, where saying that type `A` is a sub-type of `B` means that all instances of `A` are included in the domain of the type `B`.
 
 The algorithm we show in the following section computes the canonical form for a RAML type.
-It takes as input a RAML type in expanded form and produces the canonical form as output or throws an error if an inconsistency structurally or in a constraint is found
+It takes as input a RAML type in expanded form and produces the canonical form as output or throws an error if an inconsistency structurally or in a constraint is found.
 
 For example, provided the following (not expanded) RAML type:
 
@@ -232,7 +232,7 @@ The input of the algorithm is:
       1. we initialize the variable `tmp` with the output of invoking the algorithm over the value in `property-value`
       2. if the property `type` of `tmp` has the value `object`
          1. we add the pair `property-name` `tmp` to the `properties` keys in each record in `accum`
-      3. if the property `type` of `tmp` has the value `union`
+      3. if the property `type` of `tmp` has the value `union` and union hoisting is not disabled
          1. we initialize the variable `new-accum` to the empty sequence
          2. for each value `elem-of` in the property `of` of `tmp`
             1. for each value `elem` in `accum`

--- a/test/canonical.js
+++ b/test/canonical.js
@@ -21,4 +21,11 @@ describe('canonicalForm()', function () {
       expect(canForm).to.deep.equal(forms[name])
     })
   })
+  for (const name of ['Invoice', 'DiscountedInvoice']) {
+    it('should generate canonical form of type ' + name + ' with union hoisting disabled', function () {
+      const expForm = expandedForm(types[name], types)
+      const canForm = canonicalForm(expForm, { hoistUnions: false })
+      expect(canForm).to.deep.equal(forms[name + '_HoistUnionsFalse'])
+    })
+  }
 })

--- a/test/canonical.js
+++ b/test/canonical.js
@@ -3,7 +3,6 @@
 const describe = require('mocha/lib/mocha.js').describe
 const it = require('mocha/lib/mocha.js').it
 
-const _ = require('lodash')
 const expect = require('chai').expect
 const types = require('./fixtures/types')
 const forms = require('./fixtures/canonical_forms')
@@ -11,21 +10,42 @@ const expandedForm = require('..').expandedForm
 const canonicalForm = require('..').canonicalForm
 
 describe('canonicalForm()', function () {
-  _.each(types, function (type, name) {
-    it('should generate canonical form of type ' + name, function () {
-      // don't run tests for forms that don't exist
-      if (forms[name] == null) return
+  for (const name in types) {
+    // don't run tests for forms that don't exist
+    if (forms[name] != null) {
+      it('should generate canonical form of type ' + name, function () {
+        const expForm = expandedForm(types[name], types)
+        const canForm = canonicalForm(expForm)
+        expect(canForm).to.deep.equal(forms[name])
+      })
 
-      const expForm = expandedForm(types[name], types)
-      const canForm = canonicalForm(expForm)
-      expect(canForm).to.deep.equal(forms[name])
-    })
-  })
-  for (const name of ['Invoice', 'DiscountedInvoice']) {
-    it('should generate canonical form of type ' + name + ' with union hoisting disabled', function () {
-      const expForm = expandedForm(types[name], types)
-      const canForm = canonicalForm(expForm, { hoistUnions: false })
-      expect(canForm).to.deep.equal(forms[name + '_HoistUnionsFalse'])
-    })
+      it('should asynchronously generate canonical form of type ' + name, function (done) {
+        const expForm = expandedForm(types[name], types)
+        canonicalForm(expForm, function (e, result) {
+          expect(result).to.deep.equal(forms[name])
+          done()
+        })
+      })
+    }
+
+    const unhoistedName = name + '_unhoisted'
+    if (unhoistedName in forms) {
+      it('should generate canonical form of type ' + name + ' with union hoisting disabled', function () {
+        const expForm = expandedForm(types[name], types)
+        const canForm = canonicalForm(expForm, { hoistUnions: false })
+        expect(canForm).to.deep.equal(forms[unhoistedName])
+      })
+
+      it('should asynchronously generate canonical form of type ' + name + ' with union hoisting disabled', function (done) {
+        const expForm = expandedForm(types[name], types)
+        canonicalForm(expForm, {
+          hoistUnions: false,
+          callback: function (e, result) {
+            expect(result).to.deep.equal(forms[unhoistedName])
+            done()
+          }
+        })
+      })
+    }
   }
 })

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1338,5 +1338,52 @@ module.exports = {
       type: 'object',
       additionalProperties: true
     }]
+  },
+  Invoice_HoistUnionsFalse: {
+    type: 'object',
+    properties: {
+      subtotal: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      tax: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      total: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  DiscountedInvoice_HoistUnionsFalse: {
+    type: 'object',
+    properties: {
+      subtotal: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      tax: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      total: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      discount: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1339,7 +1339,7 @@ module.exports = {
       additionalProperties: true
     }]
   },
-  Invoice_HoistUnionsFalse: {
+  Invoice_unhoisted: {
     type: 'object',
     properties: {
       subtotal: {
@@ -1360,7 +1360,7 @@ module.exports = {
     },
     additionalProperties: true
   },
-  DiscountedInvoice_HoistUnionsFalse: {
+  DiscountedInvoice_unhoisted: {
     type: 'object',
     properties: {
       subtotal: {

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1263,5 +1263,80 @@ module.exports = {
         additionalProperties: true
       }
     }]
+  },
+  Invoice: {
+    type: 'union',
+    anyOf: [{
+      properties: {
+        subtotal: { type: 'number', required: true },
+        tax: { type: 'number', required: true },
+        total: { type: 'number', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'string', required: true },
+        tax: { type: 'number', required: true },
+        total: { type: 'number', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'number', required: true },
+        tax: { type: 'string', required: true },
+        total: { type: 'number', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'string', required: true },
+        tax: { type: 'string', required: true },
+        total: { type: 'number', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'number', required: true },
+        tax: { type: 'number', required: true },
+        total: { type: 'string', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'string', required: true },
+        tax: { type: 'number', required: true },
+        total: { type: 'string', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'number', required: true },
+        tax: { type: 'string', required: true },
+        total: { type: 'string', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    },
+    {
+      properties: {
+        subtotal: { type: 'string', required: true },
+        tax: { type: 'string', required: true },
+        total: { type: 'string', required: true }
+      },
+      type: 'object',
+      additionalProperties: true
+    }]
   }
 }

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1472,5 +1472,36 @@ module.exports = {
       }
     },
     additionalProperties: true
+  },
+  DiscountedInvoice: {
+    type: {
+      type: 'object',
+      properties: {
+        subtotal: {
+          type: 'union',
+          anyOf: [{ type: 'number' }, { type: 'string' }],
+          required: true
+        },
+        tax: {
+          type: 'union',
+          anyOf: [{ type: 'number' }, { type: 'string' }],
+          required: true
+        },
+        total: {
+          type: 'union',
+          anyOf: [{ type: 'number' }, { type: 'string' }],
+          required: true
+        }
+      },
+      additionalProperties: true
+    },
+    properties: {
+      discount: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1451,5 +1451,26 @@ module.exports = {
       }
     },
     additionalProperties: true
+  },
+  Invoice: {
+    type: 'object',
+    properties: {
+      subtotal: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      tax: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      },
+      total: {
+        type: 'union',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -682,5 +682,12 @@ module.exports = {
         type: 'Payments'
       }
     }
+  },
+  Invoice: {
+    properties: {
+      subtotal: 'number | string',
+      tax: 'number | string',
+      total: 'number | string'
+    }
   }
 }

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -689,5 +689,11 @@ module.exports = {
       tax: 'number | string',
       total: 'number | string'
     }
+  },
+  DiscountedInvoice: {
+    type: 'Invoice',
+    properties: {
+      discount: 'number | string'
+    }
   }
 }


### PR DESCRIPTION
Fixes #75.

This PR currently targets branch `raml2obj_integration`, but should be retargeted to `master` after that branch is merged.