### PR TITLE
Add options to expandedForm and allow original types to be tracked

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ The form and the algorithm to compute is [documented here](doc/algorithms.md).
 ### Usage
 
 The Node.js interface for the library offers the `expandedForm` function to compute the expanded form.
-It accepts an in-memory JSON representation of the type, the types mapping and a callback function.
-If the invocation succeeds, it will return the expanded form as an argument to the provided callback function.
+It accepts an in-memory JSON representation of the type, the types mapping and an optional callback function or options object.
+It returns the canonical form or an exception. The following options are supported:
+
+* `callback`: Provides a callback function via the options object.
+* `topLevel` (default: `any`): The default RAML type to use when base type is not explicit and cannot be inferred.
+It can be `any` or `string`, depending on whether the type comes from the `body` of a RAML service.
+* `trackOriginalType` (default: `false`): Controls whether expansion should track the original type in a property called `originalType` when expanding a type reference.
 
 #### Sync API
 ```js

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -54,9 +54,8 @@ module.exports.expandedForm = function expandedForm (type, types, cb) {
  * @returns {object} - expanded form
  */
 function expandForm (form, bindings, visited, options) {
-  // 1. if `form` is a `String
+  // apparently they want this
   if (typeof form === 'string') {
-    // apparently they want this
     try {
       JSON.parse(form)
       form = {
@@ -64,7 +63,10 @@ function expandForm (form, bindings, visited, options) {
         content: form
       }
     } catch (e) {}
+  }
 
+  // 1. if `form` is a `String
+  if (typeof form === 'string') {
     // strip parentheses around entire form
     if (/^\(.+\)$/.test(form)) {
       form = form.match(/^\((.+)\)$/)[1]

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -118,16 +118,15 @@ function expandForm (form, bindings, visited, options) {
         // `bindings` mapping and we add the type to the current traverse path
         visited = Object.assign({ [form]: true }, visited)
         let type = bindings[form]
-        if (options.trackOriginalType) {
-          const trackedType = {originalType: form}
-          if (typeof type === 'object') {
-            Object.assign(trackedType, type)
-          } else {
-            trackedType.type = type
-          }
-          type = trackedType
+        if (options.trackOriginalType && !(typeof type === 'object')) {
+          type = { type } // ensure type is in object form
         }
-        return expandForm(type, bindings, visited, options)
+        type = expandForm(type, bindings, visited, options)
+        // set originalType after recursive expansion to retain first type expanded
+        if (options.trackOriginalType) {
+          type.originalType = form
+        }
+        return type
       }
     }
 

--- a/test/expanded.js
+++ b/test/expanded.js
@@ -3,17 +3,43 @@
 const describe = require('mocha/lib/mocha.js').describe
 const it = require('mocha/lib/mocha.js').it
 
-const _ = require('lodash')
 const expect = require('chai').expect
 const types = require('./fixtures/types')
 const forms = require('./fixtures/expanded_forms')
 const expandedForm = require('..').expandedForm
 
 describe('expandedForm()', function () {
-  _.each(types, function (type, name) {
-    it('should generate expanded form of type ' + name, function () {
-      const expForm = expandedForm(types[name], types)
-      expect(expForm).to.deep.equal(forms[name])
-    })
-  })
+  for (const name in types) {
+    if (name in forms) {
+      it('should generate expanded form of type ' + name, function () {
+        const expForm = expandedForm(types[name], types)
+        expect(expForm).to.deep.equal(forms[name])
+      })
+
+      it('should asynchronously generate expanded form of type ' + name, function (done) {
+        expandedForm(types[name], types, function (e, result) {
+          expect(result).to.deep.equal(forms[name])
+          done()
+        })
+      })
+    }
+
+    const trackedName = name + '_tracked'
+    if (trackedName in forms) {
+      it('should generate expanded form of type ' + name + ' with original types tracked', function () {
+        const expForm = expandedForm(types[name], types, { trackOriginalType: true })
+        expect(expForm).to.deep.equal(forms[trackedName])
+      })
+
+      it('should asynchronously generate expanded form of type ' + name + ' with original types tracked', function (done) {
+        expandedForm(types[name], types, {
+          trackOriginalType: true,
+          callback: function (e, result) {
+            expect(result).to.deep.equal(forms[trackedName])
+            done()
+          }
+        })
+      })
+    }
+  }
 })

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1264,6 +1264,10 @@ module.exports = {
       }
     }]
   },
+  BigNumber: {
+    type: 'union',
+    anyOf: [{ type: 'number' }, { type: 'string' }]
+  },
   Invoice: {
     type: 'union',
     anyOf: [{
@@ -1381,6 +1385,32 @@ module.exports = {
       discount: {
         type: 'union',
         anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  ComplexTracked_unhoisted: {
+    type: 'object',
+    properties: {
+      amounts: {
+        type: 'union',
+        anyOf: [
+          {
+            type: 'union',
+            anyOf: [{ type: 'number' }, { type: 'string' }]
+          },
+          {
+            type: 'union',
+            anyOf: [{
+              type: 'array',
+              items: { type: 'number' }
+            }, {
+              type: 'array',
+              items: { type: 'string' }
+            }]
+          }
+        ],
         required: true
       }
     },

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -159,6 +159,49 @@ module.exports = {
     ],
     type: 'union'
   },
+  Device_tracked: {
+    anyOf: [
+      {
+        properties: {
+          manufacturer: {
+            type: 'string',
+            required: true
+          },
+          numberOfSIMCards: {
+            type: 'number',
+            required: true
+          },
+          kind: {
+            type: 'string',
+            required: true
+          }
+        },
+        additionalProperties: true,
+        type: 'object',
+        originalType: 'Phone'
+      },
+      {
+        properties: {
+          manufacturer: {
+            type: 'string',
+            required: true
+          },
+          numberOfUSBPorts: {
+            type: 'number',
+            required: true
+          },
+          kind: {
+            type: 'string',
+            required: true
+          }
+        },
+        additionalProperties: true,
+        type: 'object',
+        originalType: 'Notebook'
+      }
+    ],
+    type: 'union'
+  },
   Deprecation: {
     anyOf: [
       {
@@ -1452,6 +1495,41 @@ module.exports = {
     },
     additionalProperties: true
   },
+  PaymentsPage_tracked: {
+    type: 'object',
+    properties: {
+      count: {
+        type: 'integer',
+        required: true
+      },
+      results: {
+        type: {
+          type: 'array',
+          originalType: 'Payments',
+          items: {
+            type: {
+              type: 'object',
+              originalType: 'Payment',
+              properties: {
+                amount: {
+                  type: 'union',
+                  anyOf: [{ type: 'number' }, { type: 'string' }],
+                  required: true
+                }
+              },
+              additionalProperties: true
+            }
+          }
+        },
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  BigNumber: {
+    type: 'union',
+    anyOf: [{ type: 'number' }, { type: 'string' }]
+  },
   Invoice: {
     type: 'object',
     properties: {
@@ -1499,6 +1577,67 @@ module.exports = {
       discount: {
         type: 'union',
         anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  DiscountedInvoice_tracked: {
+    type: {
+      type: 'object',
+      originalType: 'Invoice',
+      properties: {
+        subtotal: {
+          type: 'union',
+          originalType: 'BigNumber',
+          anyOf: [{ type: 'number' }, { type: 'string' }],
+          required: true
+        },
+        tax: {
+          type: 'union',
+          originalType: 'BigNumber',
+          anyOf: [{ type: 'number' }, { type: 'string' }],
+          required: true
+        },
+        total: {
+          type: 'union',
+          originalType: 'BigNumber',
+          anyOf: [{ type: 'number' }, { type: 'string' }],
+          required: true
+        }
+      },
+      additionalProperties: true
+    },
+    properties: {
+      discount: {
+        type: 'union',
+        originalType: 'BigNumber',
+        anyOf: [{ type: 'number' }, { type: 'string' }],
+        required: true
+      }
+    },
+    additionalProperties: true
+  },
+  ComplexTracked_tracked: {
+    type: 'object',
+    properties: {
+      amounts: {
+        type: 'union',
+        anyOf: [
+          {
+            type: 'union',
+            originalType: 'BigNumber',
+            anyOf: [{ type: 'number' }, { type: 'string' }]
+          },
+          {
+            type: 'array',
+            items: {
+              type: 'union',
+              originalType: 'BigNumber',
+              anyOf: [{ type: 'number' }, { type: 'string' }]
+            }
+          }
+        ],
         required: true
       }
     },

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -683,17 +683,23 @@ module.exports = {
       }
     }
   },
+  BigNumber: 'number | string',
   Invoice: {
     properties: {
-      subtotal: 'number | string',
-      tax: 'number | string',
-      total: 'number | string'
+      subtotal: 'BigNumber',
+      tax: 'BigNumber',
+      total: 'BigNumber'
     }
   },
   DiscountedInvoice: {
     type: 'Invoice',
     properties: {
-      discount: 'number | string'
+      discount: 'BigNumber'
+    }
+  },
+  ComplexTracked: {
+    properties: {
+      amounts: 'BigNumber | (BigNumber[])'
     }
   },
   T1: {


### PR DESCRIPTION
As discussed in the raml2html Slack channel, it would be very useful for documentation generators to track from which named types a type reference was expanded. For instance, consider these types:

```js
{
  BigNumber: 'number | string',
  Invoice: {
    properties: {
      subtotal: 'BigNumber',
      tax: 'BigNumber',
      total: 'BigNumber'
    }
  },
  DiscountedInvoice: {
    type: 'Invoice',
    properties: {
      discount: 'BigNumber'
    }
  }
}
```

The normal expanded form would be:

```js
{
  BigNumber: {
    type: 'union',
    anyOf: [{ type: 'number' }, { type: 'string' }]
  },
  Invoice: {
    type: 'object',
    properties: {
      subtotal: {
        type: 'union',
        anyOf: [{ type: 'number' }, { type: 'string' }],
        required: true
      },
      tax: {
        type: 'union',
        anyOf: [{ type: 'number' }, { type: 'string' }],
        required: true
      },
      total: {
        type: 'union',
        anyOf: [{ type: 'number' }, { type: 'string' }],
        required: true
      }
    },
    additionalProperties: true
  },
  DiscountedInvoice: {
    type: {
      type: 'object',
      properties: {
...
  }
}
```

The fact that the unions were expanded from `BigNumber` is lost, meaning that a doc generator doesn't have the option of linking to its definition, rather than always showing the expanded union. Similarly, the fact that `DiscountedInvoice` inherits from `Invoice` is also lost. With this change, if the option `{ trackOriginalType: true }` is passed to `expandedForm`, the expanded form will include an `originalType` property whenever a type reference is expanded, e.g.:

```js
...
  DiscountedInvoice: {
    type: {
      type: 'object',
      originalType: 'Invoice',
      properties: {
        subtotal: {
          type: 'union',
          originalType: 'BigNumber',
          anyOf: [{ type: 'number' }, { type: 'string' }],
          required: true
        },
...
```

This change also clarifies that the types mapping passed to `expandedForm` is an object rather than an array, and replaces the `context` array with the `visited` object (so that checking for cycles is O(1) rather than O(N)).