### PR TITLE
Don't hoist unions from array items when hoistUnions is false

### DIFF
--- a/src/canonical.js
+++ b/src/canonical.js
@@ -61,7 +61,7 @@ function toCanonical (form, options) {
       return consistencyCheck(node)
     }
     // 3.4. if `items-type` has a value `union`
-    if (itemsType === 'union') {
+    if (itemsType === 'union' && options.hoistUnions !== false) {
       // 3.4.1. for each value `elem` in position `i` of the property `of` in `items-type`
       // 3.4.1.3. we replace the element `i` in the property `of` in `items-type` with the modified value in `union-array`
       items.anyOf = items.anyOf.map((elem) => {

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -1382,6 +1382,18 @@ module.exports = {
         type: 'union',
         anyOf: [{ type: 'number' }, { type: 'string' }],
         required: true
+      },
+      discounts: {
+        type: 'array',
+        items: {
+          type: 'union',
+          anyOf: [{
+            type: 'number'
+          }, {
+            type: 'string'
+          }]
+        },
+        required: true
       }
     },
     additionalProperties: true

--- a/test/fixtures/expanded_forms.js
+++ b/test/fixtures/expanded_forms.js
@@ -1500,6 +1500,18 @@ module.exports = {
         type: 'union',
         anyOf: [{ type: 'number' }, { type: 'string' }],
         required: true
+      },
+      discounts: {
+        type: 'array',
+        items: {
+          type: 'union',
+          anyOf: [{
+            type: 'number'
+          }, {
+            type: 'string'
+          }]
+        },
+        required: true
       }
     },
     additionalProperties: true

--- a/test/fixtures/types.js
+++ b/test/fixtures/types.js
@@ -693,7 +693,11 @@ module.exports = {
   DiscountedInvoice: {
     type: 'Invoice',
     properties: {
-      discount: 'number | string'
+      discount: 'number | string',
+      discounts: {
+        type: 'array',
+        items: 'number | string'
+      }
     }
   }
 }


### PR DESCRIPTION
Disabling `hoistUnions` should also include not transforming `(X|Y)[]` into `X[] | Y[]`.

Note that the transformation as currently implemented and specified by the algorithm (3.4) doesn't seem valid. For example, say X is number and Y is string. `[123, 'abc']` is valid according to `(number|string)[]`, but not according to `number[] | string[]`. To put it another way, hoisting unions out of arrays may not be valid regardless of settings. If others agree, I can change this PR to remove 3.4 entirely. However, if that change seems too drastic for now, it would be very helpful to me to merge this low-risk PR. This immediate issue is blocking some raml2html work.