### PR TITLE
Remove invalid canonicalization rule 3.4: hoisting unions out of array items

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -218,17 +218,8 @@ The input of the algorithm is:
 2. if `type` is in the set `any boolean datetime datetime-only number integer string null file xml json"`
    1. we return the output of applying the `consistency-check` to the `form`
 3. if `type` is the string `array`
-   1. we initialize the variable `items` with the output of applying the algorithm to the value of the key `items` of the input `form` (or `any` if the key `items` is not defined)
-   2. we initialize the variable `items-type` with the value of the `type` property of the `items` variable
-   3. if `items-type` has a value `array`
-      1. we replace the property `items` in `form` with the value of `items` variable
-      2. we return the output of applying the `consistency-check` algorithm to the new value of `form`
-   4. if `items-type` has a value `union`
-      1. for each value `elem` in position `i` of the property `of` in `items-type`
-         1. we initialize the variable `union-array` cloning the value of `form`
-         2. we replace the property `items` of the cloned value in `union-array` with `elem`
-         3. we replace the element `i` in the property `of` in `items-type` with the modified value in `union-array`
-         4. we return the output of applying the `consistency-check` algorithm to `items-type`
+   1. we replace the property `items` in `form` with the output of applying the algorithm to the value of the key `items` of the input `form` (or `any` if the key `items` is not defined)
+   2. we return the output of applying the `consistency-check` algorithm to the new value of `form`
 4. if `type` is the string `object`
    1. we initialize the variable properties with the value of the `properties` key in `form`
    2. we initialize the variable `accum` with the cloned value of `form`

--- a/src/canonical.js
+++ b/src/canonical.js
@@ -48,38 +48,11 @@ function toCanonical (form, options) {
     return consistencyCheck(form)
   } else if (type === 'array') {
     // 3. if `type` is the string `array`
-    // 3.1. we initialize the variable `items` with the output of applying the algorithm to the value of the key `items` of the input `form` of type `Record[String]RAMLForm]`
-    const items = toCanonical(form.items || {type: 'any'}, options)
-    const node = consistencyCheck(form)
-    // 3.2. we initialize the variable `items-type` with the value of the `type` property of the `items` variable
-    const itemsType = items.type
-    // 3.3. if `items-type` has a value `array`
-    if (itemsType === 'array') {
-      // 3.3.1. we replace the property `items` in `form` with the value of `items` variable
-      node.items = items
-      // 3.3.2. we return the output of applying the `consistency-check` algorithm to the new value of `form`
-      return consistencyCheck(node)
-    }
-    // 3.4. if `items-type` has a value `union`
-    if (itemsType === 'union') {
-      // 3.4.1. for each value `elem` in position `i` of the property `of` in `items-type`
-      // 3.4.1.3. we replace the element `i` in the property `of` in `items-type` with the modified value in `union-array`
-      items.anyOf = items.anyOf.map((elem) => {
-        // 3.4.1.1. we initialize the variable `union-array` cloning the value of `form`
-        const unionArray = _.cloneDeep(node)
-        // 3.4.1.2. we replace the property `items` of the cloned value in `union-array` with `elem`
-        unionArray.items = elem
-        // 3.4.1.4. we return the output of applying the `consistency-check` algorithm to `items-type`
-        return unionArray
-      })
-      if (typeof form.required === 'boolean') {
-        items.required = form.required
-      }
-      return items
-    }
-
-    node.items = items
-    return consistencyCheck(node)
+    // 3.1. we replace the property `items` in `form` with the output of applying the algorithm to
+    // the value of the key `items` of the input `form` (or `any` if the key `items` is not defined)
+    form.items = toCanonical(form.items || {type: 'any'}, options)
+    // 3.2. we return the output of applying the `consistency-check` algorithm to the new value of `form`
+    return consistencyCheck(form)
   } else if (type === 'object') {
     // 4. if `type` is the string `object`
     // 4.1. we initialize the variable properties with the value of the `properties` key in `form`

--- a/test/fixtures/canonical_forms.js
+++ b/test/fixtures/canonical_forms.js
@@ -523,17 +523,17 @@ module.exports = {
     additionalProperties: true
   },
   'Songs.Musician': {
-    type: 'union',
-    anyOf: [
-      {
-        properties: {
-          name: {
-            type: 'string',
-            required: true
-          },
-          discography: {
-            type: 'array',
-            items: {
+    properties: {
+      name: {
+        type: 'string',
+        required: true
+      },
+      discography: {
+        type: 'array',
+        items: {
+          type: 'union',
+          anyOf: [
+            {
               properties: {
                 title: {
                   type: 'string',
@@ -547,21 +547,7 @@ module.exports = {
               type: 'object',
               additionalProperties: true
             },
-            required: true
-          }
-        },
-        type: 'object',
-        additionalProperties: true
-      },
-      {
-        properties: {
-          name: {
-            type: 'string',
-            required: true
-          },
-          discography: {
-            type: 'array',
-            items: {
+            {
               properties: {
                 title: {
                   type: 'string',
@@ -588,14 +574,14 @@ module.exports = {
               },
               type: 'object',
               additionalProperties: true
-            },
-            required: true
-          }
+            }
+          ]
         },
-        type: 'object',
-        additionalProperties: true
+        required: true
       }
-    ]
+    },
+    type: 'object',
+    additionalProperties: true
   },
   'Songs.C': {
     type: 'object',
@@ -1123,18 +1109,15 @@ module.exports = {
     additionalProperties: true
   },
   UnionArray: {
-    type: 'union',
-    anyOf: [{
-      type: 'array',
-      items: {
+    type: 'array',
+    items: {
+      type: 'union',
+      anyOf: [{
         type: 'string'
-      }
-    }, {
-      type: 'array',
-      items: {
+      }, {
         type: 'number'
-      }
-    }]
+      }]
+    }
   },
   UnionInheritance: {
     'type': 'union',
@@ -1237,10 +1220,10 @@ module.exports = {
     }]
   },
   Payments: {
-    type: 'union',
-    anyOf: [{
-      type: 'array',
-      items: {
+    type: 'array',
+    items: {
+      type: 'union',
+      anyOf: [{
         type: 'object',
         properties: {
           amount: {
@@ -1249,10 +1232,7 @@ module.exports = {
           }
         },
         additionalProperties: true
-      }
-    }, {
-      type: 'array',
-      items: {
+      }, {
         type: 'object',
         properties: {
           amount: {
@@ -1261,8 +1241,8 @@ module.exports = {
           }
         },
         additionalProperties: true
-      }
-    }]
+      }]
+    }
   },
   Invoice: {
     type: 'union',


### PR DESCRIPTION
Transforming `(X|Y)[]` into `X[] | Y[]` is invalid. With that step removed,
the remainder of rule 3 can be greatly simplified.

This supersedes #89.
